### PR TITLE
do not print request body on Catalog.save()

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -288,7 +288,6 @@ class Catalog(object):
         netloc = urlparse(self.service_url).netloc
         rest_url = href._replace(netloc=netloc).geturl()
         data = obj.message()
-        print(data)
 
         headers = {
             "Content-type": content_type,


### PR DESCRIPTION
Catalog.save() may be used with UnsavedDataStore, and then request body contains password. And password is printed to stdout. If someone have to print or log object data, it can be done outside save().