### PR TITLE
Use get_resource with known store name

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -686,7 +686,7 @@ class Catalog(object):
                 )
 
         self._cache.clear()
-        #return self.get_resources(names=layer_name, workspaces=[workspace])[0]
+        return self.get_resource(name=layer_name,store=name, workspace=workspace)
 
     def add_granule(self, data, store, workspace=None):
         """Harvest/add a granule into an existing imagemosaic"""

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -686,7 +686,7 @@ class Catalog(object):
                 )
 
         self._cache.clear()
-        return self.get_resources(names=layer_name, workspaces=[workspace])[0]
+        #return self.get_resources(names=layer_name, workspaces=[workspace])[0]
 
     def add_granule(self, data, store, workspace=None):
         """Harvest/add a granule into an existing imagemosaic"""


### PR DESCRIPTION
Calling get_resources without a store causes a loop over all the existing stores in geoserver.
As we now the created store name we can reuse it and speed up the creation step.