### PR TITLE
A fix to use the style format parameter when updating existing styles

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -1311,6 +1311,7 @@ class Catalog(object):
                 )
 
         if style:
+            style.style_format = style_format
             headers = {"Content-type": style.content_type, "Accept": "application/xml"}
 
             body_href = style.body_href


### PR DESCRIPTION
This resolves an issue with the create_style method where if the style already exists then the style format parameter is not being used as part of the update.